### PR TITLE
Fix Zipper crash for Spanned Zip / Self Ext Zip

### DIFF
--- a/source/AbZipper.pas
+++ b/source/AbZipper.pas
@@ -459,7 +459,7 @@ begin
         ArcType := AbDetermineArcType(FileName, atUnknown);
 
       case ArcType of
-        atZip : begin                                                    
+        atZip, atSpannedZip, atSelfExtZip : begin                                                    
           FArchive := TAbZipArchive.Create(FileName, fmCreate);
           InitArchive;
         end;


### PR DESCRIPTION
AbZipper crashed with "Unknown archive type" when setting FileName after forcing the ArcType to atSpannedZip or atSelfExtZip. This adds those type cases.

Example for a crash:
```
function CreateZipper(FileName: String; SpanningThreshold: Integer): TAbZipper;
begin
  Result := TAbZipper.Create(Owner);
  Result.ForceType := true;
  Result.ArchiveType := atSpannedZip;
  Result.FileName := FileName; // Throws exception
  Result.SpanningThreshold := SpanningThreshold;
  Result.DeflationOption := doMaximum;
end;
```