### PR TITLE
Added dpm package spec and supporting files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,6 @@
 # Denote all files that are truly binary and should not be modified.
 *.exe binary
 *.res binary
+
+# dpm support - post commit hook updates the dspec file with the commit hash
+*.dspec filter=insert-hash

--- a/TurboPack.Abbrevia.dspec
+++ b/TurboPack.Abbrevia.dspec
@@ -1,0 +1,57 @@
+# DPM package spec file
+min dpm client version: 1.0.0
+metadata:
+  id: TurboPack.Abbrevia
+  version: 13.0.0
+  description: Abbrevia is a compression toolkit for Delphi
+  authors:
+    - 'TurboPower Software, Roman Kassebaum'
+  projectUrl: https://github.com/TurboPack/Abbrevia
+  repositoryUrl: https://github.com/TurboPack/Abbrevia
+  repositoryCommit: '#HASH#'
+  license: MPL-1.1
+  copyright: 'TurboPower Software, Roman Kassebaum and contributors'
+  tags:
+    - zip
+    - archive
+    - bzip
+    - lzma
+  readme: readme.txt
+variables:
+  packagesource: /packages/11AndAbove/Delphi
+targetPlatforms:
+  - compiler: delphi12.0
+    platforms:
+      - win32
+      - win64
+  - compiler: delphi13.0
+    platforms:
+      - win32
+      - win64
+      - winarm64ec
+templates:
+  - name: default
+    source:
+      - src: ./source/*.pas
+      - src: ./source/*.inc
+      - src: ./source/*.dfm
+        copyToLib: true
+      - src: ./source/*.fmx
+        copyToLib: true
+      - src: ./source/*.res
+      - src: ./source/Win32/*.*
+      - src: ./source/Win64/*.*
+      - src: ./source/WinARM64EC/*.*
+      - src: $packageSource$/*.dpk
+      - src: $packageSource$/*.dproj
+      - src: $packageSource$/*.res
+      - src: $packageSource$/*.ico
+      - src: ./localization/*.*
+      - src: ./icons/*.*
+      - src: ./thirdparty/**/*.*
+    build:
+      - project: $packageSource$/AbbreviaD.dproj
+      - project: $packageSource$/AbbreviaVCLD.dproj
+    design:
+      - project: $packageSource$/AbbreviaVCLDDesign.dproj
+      - project: $packageSource$/AbbreviaFMXDDesign.dproj

--- a/gitconfig.bat
+++ b/gitconfig.bat
@@ -1,0 +1,6 @@
+REM ensure the current commit hash is added to *.dspec
+REM Only needed for package publishing - for owner use only.
+
+git config filter.insert-hash.smudge "sh -c 'hash=$(git rev-parse HEAD); sed s/#HASH#/Id:$hash/g'"
+git config filter.insert-hash.clean "sh -c 'sed -E 's/Id:[0-9a-fA-F]{40}/#HASH#/g''"
+copy post-commit.txt .git\hooks\post-commit

--- a/post-commit.txt
+++ b/post-commit.txt
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Post commit hook to force all .dspec and .dspec.yaml files to always have current commit hash
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Define the source folder to search
+# In this project
+SOURCE_FOLDER="./"
+
+echo -e "${YELLOW}Post-commit hook: Processing .dspec and .dspec.yaml files in ${SOURCE_FOLDER} folder${NC}"
+
+# Find all .dspec and .dspec.yaml files in the Source folder
+DSPEC_FILES=$(find "$SOURCE_FOLDER" \( -name "*.dspec" -o -name "*.dspec.yaml" \) -type f 2>/dev/null)
+
+if [ -z "$DSPEC_FILES" ]; then
+    echo -e "${YELLOW}No .dspec or .dspec.yaml files found in ${SOURCE_FOLDER} folder${NC}"
+    exit 0
+fi
+
+echo -e "${YELLOW}Found files:${NC}"
+echo "$DSPEC_FILES" | while read -r file; do
+    echo -e "  ${YELLOW}$file${NC}"
+done
+
+# Process each .dspec file
+echo "$DSPEC_FILES" | while read -r TARGET_FILE; do
+    echo -e "\n${YELLOW}Processing: ${TARGET_FILE}${NC}"
+    
+    # Check if the target file exists
+    if [ -f "$TARGET_FILE" ]; then
+        echo -e "${RED}Deleting ${TARGET_FILE}${NC}"
+        rm "$TARGET_FILE"
+        
+        # Verify deletion
+        if [ ! -f "$TARGET_FILE" ]; then
+            echo -e "${GREEN}File successfully deleted${NC}"
+        else
+            echo -e "${RED}Error: Failed to delete ${TARGET_FILE}${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}File ${TARGET_FILE} does not exist, skipping deletion${NC}"
+    fi
+
+    # Force checkout the file from the repository
+    echo -e "${YELLOW}Force checking out ${TARGET_FILE} from HEAD${NC}"
+
+    # Use git checkout to restore the file from the latest commit
+    git checkout HEAD -- "$TARGET_FILE"
+
+    # Check if the checkout was successful
+    if [ $? -eq 0 ]; then
+        if [ -f "$TARGET_FILE" ]; then
+            echo -e "${GREEN}Successfully restored ${TARGET_FILE} from repository${NC}"
+        else
+            echo -e "${YELLOW}File ${TARGET_FILE} was not restored (may not exist in repository)${NC}"
+        fi
+    else
+        echo -e "${RED}Error: Failed to checkout ${TARGET_FILE}${NC}"
+        exit 1
+    fi
+done
+
+echo -e "\n${GREEN}Post-commit hook completed successfully${NC}"


### PR DESCRIPTION
Hi

This PR add the file needed to create a [dpm](https://delphi.dev) package for Abbrevia. DPM is a package manager (like Nuget or npm) for Delphi.

Publishing dpm packages is relatively simple (first time requires some signup). 

Register on the website - if you don't use Github/Google auth then enable 2FA on your account settings once logged in (this is needed for publishers). 

Create an Organisation - TurboPower.
Create an API Key - set the package owneer to the organisation

Install the DPM client (download link on the website). It also installs a tool called DSpecCreator.exe - you can use this to edit the Turbpack.Abbrevia.dspec file (or you an edit it in any editor, it's yaml). Edit the file as needed. I could only get the library to compile in D12 & 13 - so those are the only compiler versions I enabled in the dspec. I set the package version to 13.0.0 - adjust as needed - note that dpm uses [semantic versioning](https://semver.org/) - so for package versions you should bear that in mind when publishing updates. 

Then (optional) run the gitconfig.bat file to install the postcommit hook so that the the dspec file gets the commit hash inserted after commit (provides traceability). Once your changes are committed, use the DSpecCreator tool to Pack, Test and Upload the resulting packages to the server - they will appear on the site a few minutes after upload (some checks are performed first).

If you are able or willing to do this let me know and I will publish it (it's better if the authors/maintainers publish). 

FWIW, someone who uses dpm and Abbrevia requested this package.