### PR TITLE
Fixed compilation for 10.1-11.x and updated dspec

### DIFF
--- a/TurboPack.Abbrevia.dspec
+++ b/TurboPack.Abbrevia.dspec
@@ -20,7 +20,32 @@ metadata:
 variables:
   packagesource: /packages/11AndAbove/Delphi
 targetPlatforms:
-  - compiler: delphi12.0
+  - compiler: delphi10.1
+    platforms:
+      - win32
+      - win64
+    variables:
+      packageSource: /packages/Berlin/Delphi
+  - compiler: delphi10.2
+    platforms:
+      - win32
+      - win64
+    variables:
+      packageSource: /packages/Tokyo/Delphi
+  - compiler: delphi10.3
+    platforms:
+      - win32
+      - win64
+    variables:
+      packageSource: /packages/Rio/Delphi
+  - compiler: delphi10.4
+    platforms:
+      - win32
+      - win64
+    variables:
+      packageSource: /packages/Sydney/Delphi
+  - compiler from: delphi11.0
+    compiler to: delphi12.0
     platforms:
       - win32
       - win64

--- a/source/AbCompnd.pas
+++ b/source/AbCompnd.pas
@@ -37,7 +37,7 @@ unit AbCompnd;
 interface
 
 uses
-  Classes, SysUtils, ComCtrls, AbBase, AbResString, AbDfDec, AbDfEnc, AbDfBase;
+  AbUtils, Classes, SysUtils, ComCtrls, AbBase, AbResString, AbDfDec, AbDfEnc, AbDfBase;
 
 const
   AbCompoundFileVersion = '3.1';
@@ -356,7 +356,7 @@ type
 implementation
 
 uses
-  StrUtils, AnsiStrings, ABUtils;
+  StrUtils, AnsiStrings;
 
 {-----------------------------------------------------------------------------}
 {-----------------------------------------------------------------------------}


### PR DESCRIPTION
This PR fixes the build issue with delphi 10.1 - 11.x (I did test on each version).

The dpm dspec file now includes those compiler versions.